### PR TITLE
Adding "yarn-error.log" to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@
 .babelrc
 .eslintrc
 npm-debug.log
+yarn-error.log
 lib
 bundle-test
 src


### PR DESCRIPTION
There's currently "yarn-error.log" file in the package (npmjs.org).
This will prevent "yarn-error.log" file from being published in the future.