### PR TITLE
add UtcOffset scalar

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ In your schema:
 ```graphql
 scalar DateTime
 
+scalar UtcOffset
+
 scalar EmailAddress
 
 scalar NegativeFloat
@@ -96,6 +98,7 @@ In your resolver map, first import them:
 ```javascript
 import {
   DateTimeResolver,
+  UtcOffsetResolver,
   EmailAddressResolver,
   NegativeFloatResolver,
   NegativeIntResolver,
@@ -137,6 +140,7 @@ const myResolverMap = {
   ObjectID: ObjectIDResolver,
 
   DateTime: DateTimeResolver,
+  UtcOffset: UtcOffsetResolver,
 
   NonPositiveInt: NonPositiveIntResolver,
   PositiveInt: PositiveIntResolver,
@@ -429,6 +433,10 @@ Use real JavaScript Dates for GraphQL fields. Currently you can use a String or 
 timestamp in milliseconds) to represent a date/time. This scalar makes it easy to be explicit about
 the type and have a real JavaScript Date returned that the client can use _without_ doing the
 inevitable parsing or conversion themselves.
+
+### UtcOffset
+
+String that will have a value of format ±hh:mm. [`List of tz database time zones`](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
 ### NonNegativeInt
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import * as mocks from './mocks';
 
 export {
   DateTime as DateTimeTypeDefinition,
+  UtcOffset as UtcOffsetTypeDefinition,
   EmailAddress as EmailAddressTypeDefinition,
   NegativeFloat as NegativeFloatTypeDefinition,
   NegativeInt as NegativeIntTypeDefinition,
@@ -43,6 +44,7 @@ export { default as typeDefs } from './typeDefs';
 
 export {
   DateTime as DateTimeResolver,
+  UtcOffset as UtcOffsetResolver,
   EmailAddress as EmailAddressResolver,
   NegativeFloat as NegativeFloatResolver,
   NegativeInt as NegativeIntResolver,
@@ -81,6 +83,7 @@ export {
 
 export {
   DateTime as GraphQLDateTime,
+  UtcOffset as GraphQLUtcOffset,
   EmailAddress as GraphQLEmailAddress,
   NegativeFloat as GraphQLNegativeFloat,
   NegativeInt as GraphQLNegativeInt,
@@ -121,6 +124,7 @@ export { resolvers };
 
 export {
   DateTime as DateTimeMock,
+  UtcOffset as UtcOffsetMock,
   EmailAddress as EmailAddressMock,
   NegativeFloat as NegativeFloatMock,
   NegativeInt as NegativeIntMock,

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -1,5 +1,6 @@
 const BigIntMock = () => BigInt(Number.MAX_SAFE_INTEGER);
 export const DateTime = () => new Date();
+export const UtcOffset = () => '+03:00';
 export const EmailAddress = () => 'test@test.com';
 export const NegativeFloat = () => -123.45;
 export const NegativeInt = () => -123;

--- a/src/resolvers/UtcOffset.ts
+++ b/src/resolvers/UtcOffset.ts
@@ -1,0 +1,36 @@
+import { Kind, GraphQLError, GraphQLScalarType } from 'graphql';
+
+const validate = (value: any) => {
+  const UTC_OFFSET_REGEX = /^([+-]?)(\d{2}):(\d{2})$/;
+
+  if (typeof value !== 'string') {
+    throw new TypeError(`Value is not string: ${value}`);
+  }
+
+  if (!UTC_OFFSET_REGEX.test(value)) {
+    throw new TypeError(`Value is not a valid UTC Offset: ${value}`);
+  }
+
+  return value;
+};
+
+export default new GraphQLScalarType({
+  name: 'UtcOffset',
+
+  description:
+    'A field whose value is a UTC Offset: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones',
+
+  serialize: validate,
+
+  parseValue: validate,
+
+  parseLiteral(ast) {
+    if (ast.kind !== Kind.STRING) {
+      throw new GraphQLError(
+        `Can only validate strings as UTC Offset but got a: ${ast.kind}`,
+      );
+    }
+
+    return validate(ast.value);
+  },
+});

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,4 +1,5 @@
 import DateTime from './DateTime';
+import UtcOffset from './UtcOffset';
 import NonPositiveInt from './NonPositiveInt';
 import PositiveInt from './PositiveInt';
 import NonNegativeIntFactory from './NonNegativeInt';
@@ -41,6 +42,7 @@ const UnsignedFloatResolver = NonNegativeFloatFactory('UnsignedFloat');
 
 export {
   DateTime,
+  UtcOffset,
   NonPositiveInt,
   PositiveInt,
   NonNegativeIntResolver as NonNegativeInt,

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -1,5 +1,6 @@
 export const BigInt = 'scalar BigInt';
 export const DateTime = 'scalar DateTime';
+export const UtcOffset = 'scalar UtcOffset';
 export const EmailAddress = 'scalar EmailAddress';
 export const GUID = `scalar GUID`;
 export const Hexadecimal = `scalar Hexadecimal`;
@@ -38,6 +39,7 @@ export const Void = 'scalar Void';
 
 export default [
   DateTime,
+  UtcOffset,
   EmailAddress,
   NegativeFloat,
   NegativeInt,

--- a/tests/UtcOffset.test.ts
+++ b/tests/UtcOffset.test.ts
@@ -1,0 +1,62 @@
+/* global describe, test, expect */
+
+import { Kind } from 'graphql/language';
+import UtcOffset from '../src/resolvers/UtcOffset';
+
+describe('UtcOffset', () => {
+  describe('valid', () => {
+    test('serialize', () => {
+      const sample = "+02:00";
+      expect(UtcOffset.serialize(sample)).toEqual(sample);
+    });
+
+    test('parseValue', () => {
+      const sample = "+05:00";
+      expect(UtcOffset.parseValue(sample)).toEqual(sample);
+    });
+
+    test('parseLiteral', () => {
+      const result = "-12:30";
+      expect(
+        UtcOffset.parseLiteral({
+          value: "-12:30",
+          kind: Kind.STRING,
+        }, {}),
+      ).toEqual(result);
+    });
+  });
+
+  describe('invalid', () => {
+    describe('not a valid date', () => {
+      test('serialize', () => {
+        expect(() => UtcOffset.serialize('this is not an utc offset')).toThrow(
+          /Value is not a valid UTC Offset/,
+        );
+      });
+
+      test('parseValue', () => {
+        expect(() => UtcOffset.parseValue('this is not an utc offset')).toThrow(
+          /Value is not a valid UTC Offset/,
+        );
+      });
+
+      test('parseLiteral', () => {
+        expect(() =>
+          UtcOffset.parseLiteral({
+            value: 'this is not an utc offset',
+            kind: Kind.STRING,
+          }, {}),
+        ).toThrow(/Value is not a valid UTC Offset/);
+      });
+
+      test('parseLiteral (Int)', () => {
+        expect(() =>
+          UtcOffset.parseLiteral({
+            value: 'this is not an utc offset',
+            kind: Kind.INT,
+          }, {}),
+        ).toThrow(/Can only validate strings as UTC Offset/);
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Motivation:**

Date time and Utc Offset seems always together.
Its easier to have 2 scalars for 1 purpose, to input DateTime (example for filtering), and the UtcOffset preferred.