### PR TITLE
Allow ordinary apostrophes in email addresses

### DIFF
--- a/src/scalars/EmailAddress.ts
+++ b/src/scalars/EmailAddress.ts
@@ -1,7 +1,7 @@
 import { Kind, GraphQLError, GraphQLScalarType } from 'graphql';
 
 const validate = (value: any) => {
-  const EMAIL_ADDRESS_REGEX = /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+  const EMAIL_ADDRESS_REGEX = /^[a-zA-Z0-9.!#$%&’'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
 
   if (typeof value !== 'string') {
     throw new TypeError(`Value is not string: ${value}`);


### PR DESCRIPTION
Ordinary apostrophes are permitted characters in the name part of an email address, according to https://tools.ietf.org/html/rfc3696.

This updates the regex to include an ordinary apostrophe.