### PR TITLE
fix(Byte): update isHex validator

### DIFF
--- a/src/scalars/Byte.ts
+++ b/src/scalars/Byte.ts
@@ -7,10 +7,9 @@ import {
   print,
 } from 'graphql';
 
-const base64Validator = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
-const hexValidator = /(0x|0X)?[a-fA-F0-9]+$/;
-
 type BufferJson = { type: 'Buffer'; data: number[] };
+const IS_HEX_FLAG = 'hex';
+const IS_BASE64_FLAG = 'b64';
 
 function validate(value: Buffer | string | BufferJson) {
   if (typeof value !== 'string' && !(value instanceof global.Buffer)) {
@@ -19,8 +18,9 @@ function validate(value: Buffer | string | BufferJson) {
     );
   }
   if (typeof value === 'string') {
-    const isBase64 = base64Validator.test(value);
-    const isHex = hexValidator.test(value);
+    const type = value.slice(0, 3);
+    const isBase64 = type === IS_BASE64_FLAG;
+    const isHex = type === IS_HEX_FLAG;
     if (!isBase64 && !isHex) {
       throw new TypeError(
         `Value is not a valid base64 or hex encoded string: ${JSON.stringify(
@@ -28,7 +28,7 @@ function validate(value: Buffer | string | BufferJson) {
         )}`,
       );
     }
-    return global.Buffer.from(value, isHex ? 'hex' : 'base64');
+    return global.Buffer.from(value.slice(3), isHex ? 'hex' : 'base64');
   }
 
   return value;

--- a/tests/Byte.test.ts
+++ b/tests/Byte.test.ts
@@ -18,10 +18,10 @@ const byte = Buffer.from([
   101,
   33,
 ]);
-const base64String = byte.toString('base64');
-const hexString = byte.toString('hex');
-const notBase64 = 'RG9kZ2VycyBSdWxlIQ=';
-const notHex = '446f64676572732052756c65z';
+const base64String = 'b64' + byte.toString('base64');
+const hexString = 'hex' + byte.toString('hex');
+const notBase64 = byte.toString('base64');
+const notHex = byte.toString('hex');
 const notByte = 1;
 
 function createBufferObject(type: string, values: ValueNode[]) {

--- a/tests/Byte.test.ts
+++ b/tests/Byte.test.ts
@@ -18,10 +18,14 @@ const byte = Buffer.from([
   101,
   33,
 ]);
-const base64String = 'b64' + byte.toString('base64');
-const hexString = 'hex' + byte.toString('hex');
-const notBase64 = byte.toString('base64');
-const notHex = byte.toString('hex');
+const base64String = byte.toString('base64');
+const hexString = byte.toString('hex');
+const notBase64 = 'RG9kZ2VycyBSdWxlIQ=';
+const notHex = '446f64676572732052756c65z';
+const looksLikeBase64 = 'c40473746174';
+const looksLikeBase64Buffer = Buffer.from(looksLikeBase64, 'hex');
+const looksLikeHex = 'xARzdGF0';
+const looksLikeHexBuffer = Buffer.from(looksLikeHex, 'base64');
 const notByte = 1;
 
 function createBufferObject(type: string, values: ValueNode[]) {
@@ -123,5 +127,18 @@ describe.each<[string, Buffer | string, string | number]>([
         }).toThrow(/Value is not a JSON representation of Buffer/);
       }
     });
+  });
+});
+
+describe.each<[string, string, Buffer]>([
+  ['Hex String desguised as base64', looksLikeBase64, looksLikeBase64Buffer],
+  ['Base64 String desguised as hex', looksLikeHex, looksLikeHexBuffer],
+])('Byte string edge cases', (testType, encodedValue, decodedValue) => {
+  test(`serialize (${testType})`, () => {
+    expect(GraphQLByte.serialize(encodedValue)).toEqual(decodedValue);
+  });
+
+  test(`parseValue (${testType})`, () => {
+    expect(GraphQLByte.parseValue(encodedValue)).toEqual(decodedValue);
   });
 });


### PR DESCRIPTION
The base64 and hex validators are not guaranteeed to work.
There are some false positive cases, so instead add a type header to
the string, so a user can specify what the encoding of the string is.