### PR TITLE
fix(Byte): hexValidator should remove leading 0

### DIFF
--- a/src/scalars/Byte.ts
+++ b/src/scalars/Byte.ts
@@ -10,6 +10,8 @@ import {
 type BufferJson = { type: 'Buffer'; data: number[] };
 const base64Validator = /^(?:[A-Za-z0-9+]{4})*(?:[A-Za-z0-9+]{2}==|[A-Za-z0-9+]{3}=)?$/;
 function hexValidator(value: string) {
+  // Ensure that any leading 0 is removed from the hex string to avoid false negatives.
+  const sanitizedValue = value.charAt(0) === '0' ? value.slice(1) : value;
   // For larger strings, we run into issues with MAX_SAFE_INTEGER, so split the string
   // into smaller pieces to avoid this issue.
   if (value.length > 8) {
@@ -23,9 +25,9 @@ function hexValidator(value: string) {
         16,
       );
     }
-    return parsedString === value;
+    return parsedString === sanitizedValue;
   }
-  return parseInt(value, 16).toString(16) === value;
+  return parseInt(value, 16).toString(16) === sanitizedValue;
 }
 
 function validate(value: Buffer | string | BufferJson) {

--- a/tests/Byte.test.ts
+++ b/tests/Byte.test.ts
@@ -18,8 +18,10 @@ const byte = Buffer.from([
   101,
   33,
 ]);
+const byteLeading0 = Buffer.from([4, 8, 15, 16, 23, 42]);
 const base64String = byte.toString('base64');
 const hexString = byte.toString('hex');
+const hexLeading0 = byteLeading0.toString('hex');
 const notBase64 = 'RG9kZ2VycyBSdWxlIQ=';
 const notHex = '446f64676572732052756c65z';
 const looksLikeBase64 = 'c40473746174';
@@ -140,5 +142,11 @@ describe.each<[string, string, Buffer]>([
 
   test(`parseValue (${testType})`, () => {
     expect(GraphQLByte.parseValue(encodedValue)).toEqual(decodedValue);
+  });
+});
+
+describe('hex with leading 0', () => {
+  test('should return true when validating', () => {
+    expect(GraphQLByte.parseValue(hexLeading0)).toEqual(byteLeading0);
   });
 });


### PR DESCRIPTION
## Description

A leading 0 in the hex string can throw off the hex validator, since
this information is lost in the parseInt action. This results in the
string check to return `false` instead of `true`, because the parsed
hex string does not contain the leading 0.

Related #716

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Added a test for a hex string containing a leading 0 (`'04080f10172a'`)

**Test Environment**:
- OS: Mac OS
- GraphQL Scalars Version: 1.7.0
- NodeJS: 14.15

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

