### PR TITLE
Update pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged
+npx --no-install lint-staged


### PR DESCRIPTION
@ardatan 

Should be a simple `npx --no-install lint-staged`.

`npx` works both in *npm* and *yarn* (as far as I know -> I'm using npm -> can you try?)

See [https://typicode.github.io/husky/#/?id=usage](https://typicode.github.io/husky/#/?id=usage)

Husky use *npx* (always).