### PR TITLE
Husky/package.json prepare script instead of postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,7 @@
     "release": "yarn prepare-release && bob prepack && npm publish dist",
     "ci:release:canary": "node bump.js && bob prepack && npm publish dist --tag alpha --access public",
     "bundlesize": "yarn build && cd bundle-test/ && yarn && yarn test",
-    "postinstall": "husky install",
-    "prepublishOnly": "pinst --disable",
-    "postpublish": "pinst --enable"
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@graphql-tools/merge": "6.2.10",
@@ -60,7 +58,6 @@
     "lint-staged": "10.5.4",
     "mockdate": "3.0.2",
     "mongodb": "3.6.4",
-    "pinst": "2.1.6",
     "prettier": "2.2.1",
     "semver": "7.3.4",
     "ts-jest": "26.5.2",


### PR DESCRIPTION
In Husky v*5.1.2* is recommend ```prepare``` script instead of ```postinstall```.

Removed Pinst since it's *useless*.

See [https://github.com/typicode/husky/releases/tag/v5.1.2](https://github.com/typicode/husky/releases/tag/v5.1.2)