### PR TITLE
improv(scalars): add Iran postalCode validation

### DIFF
--- a/src/scalars/PostalCode.ts
+++ b/src/scalars/PostalCode.ts
@@ -24,6 +24,7 @@ import { Kind, GraphQLError, GraphQLScalarType } from 'graphql';
 // PT - Portugal
 // CH - Switzerland
 // LU - Luxembourg
+// IR - Iran
 //
 // This is really a practical decision of weight (of the package) vs. completeness.
 //
@@ -49,6 +50,7 @@ const POSTAL_CODE_REGEXES = [
   /* PT */ /*#__PURE__*//^\d{4}([\-]\d{3})?$/,
   /* CH */ /*#__PURE__*//^\d{4}$/,
   /* LU */ /*#__PURE__*//^\d{4}$/,
+  /* IR */ /*#__PURE__*//^[1,3-9]{10}$/
 ];
 
 function _testPostalCode(postalCode: string) {

--- a/tests/PostalCode.test.ts
+++ b/tests/PostalCode.test.ts
@@ -280,20 +280,20 @@ describe('PostalCode', () => {
 
     describe('Iran', () => {
       test('serialize', () => {
-        expect(GraphQLPostalCode.serialize('1346789876')).toBe('1346789876');
+        expect(GraphQLPostalCode.serialize('1345678987')).toBe('1345678987');
       });
 
       test('parseValue', () => {
-        expect(GraphQLPostalCode.parseValue('1346789876')).toBe('1346789876');
+        expect(GraphQLPostalCode.parseValue('1345678987')).toBe('1345678987');
       });
 
       test('parseLiteral', () => {
         expect(
           GraphQLPostalCode.parseLiteral(
-            { value: '1346789876', kind: Kind.STRING },
+            { value: '1345678987', kind: Kind.STRING },
             {},
           ),
-        ).toBe('1346789876');
+        ).toBe('1345678987');
       });
     });
   });

--- a/tests/PostalCode.test.ts
+++ b/tests/PostalCode.test.ts
@@ -277,6 +277,25 @@ describe('PostalCode', () => {
         ).toBe('110003');
       });
     });
+
+    describe('Iran', () => {
+      test('serialize', () => {
+        expect(GraphQLPostalCode.serialize('1346789876')).toBe('1346789876');
+      });
+
+      test('parseValue', () => {
+        expect(GraphQLPostalCode.parseValue('1346789876')).toBe('1346789876');
+      });
+
+      test('parseLiteral', () => {
+        expect(
+          GraphQLPostalCode.parseLiteral(
+            { value: '1346789876', kind: Kind.STRING },
+            {},
+          ),
+        ).toBe('1346789876');
+      });
+    });
   });
 
   describe('invalid', () => {

--- a/website/docs/scalars/postal-code.md
+++ b/website/docs/scalars/postal-code.md
@@ -22,8 +22,8 @@ Which gives us the following countries:
 - SE - Sweden
 - BE - Belgium
 - IN - India
+- IR - Iran
 
 This is really a practical decision of weight (of the package) vs. completeness.
 
 In the future we might expand this list and use the more comprehensive list found [here](http://unicode.org/cldr/trac/browser/tags/release-26-0-1/common/supplemental/postalCodeData.xml).
-


### PR DESCRIPTION
## Description
This PR will add the proper regex check for Iran `postalCode` format in scalars.
It should contain only the digits below with the string length of `10`.
```
1, 3, 4, 5, 6, 7, 8, 9
```

Related #991

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Tested
- [x] Unit tests added to `postalCode.test.js`.
- [x] Tested Manually.

**Test Environment**:
- OS: `ubuntu 20.04`
- GraphQL Scalars Version: `1.10.0`
- NodeJS: `v14.17.1`

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
