### PR TITLE
fix: expose RegularExpressionOptions and RegularExpressionErrorMessageFn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -277,7 +277,11 @@ export {
 
 export { mocks };
 
-export { RegularExpression } from './RegularExpression';
+export {
+  RegularExpression,
+  RegularExpressionOptions,
+  RegularExpressionErrorMessageFn,
+} from './RegularExpression';
 
 export {
   GraphQLDate,


### PR DESCRIPTION
## Description

When using the RegularExpression factory in TypeScript the supporting definitions (functions and type) are not exposed. 
Interface: `RegularExpressionOptions`
Type: `RegularExpressionErrorMessageFn`


As a result I had to redefine the types in my code instead of using the `graphql-scalars` one

The change simply exposes these definitions on the root `index.ts` file

Related # (issue)
https://github.com/Urigo/graphql-scalars/issues/1068

## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Built and unit tested package. Two types were exposed, no functionality otherwise changed
```
yarn build
yarn test
```


**Test Environment**:
- OS: MacOS 10.15.5
- GraphQL Scalars Version: 1.10.1
- NodeJS: 14.17.5


