### PR TITLE
Adding support for base64 encoded strings containing / in it.

### DIFF
--- a/src/scalars/Byte.ts
+++ b/src/scalars/Byte.ts
@@ -9,7 +9,8 @@ import {
 } from 'graphql';
 
 type BufferJson = { type: 'Buffer'; data: number[] };
-const base64Validator = /^(?:[A-Za-z0-9+]{4})*(?:[A-Za-z0-9+]{2}==|[A-Za-z0-9+]{3}=)?$/;
+const base64Validator =
+  /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/;
 function hexValidator(value: string) {
   // Ensure that any leading 0 is removed from the hex string to avoid false negatives.
   const sanitizedValue = value.charAt(0) === '0' ? value.slice(1) : value;

--- a/tests/Byte.test.ts
+++ b/tests/Byte.test.ts
@@ -4,25 +4,18 @@ import { Kind, ValueNode } from 'graphql/language';
 import { GraphQLByte } from '../src/scalars/Byte';
 
 const byte = Buffer.from([
-  68,
-  111,
-  100,
-  103,
-  101,
-  114,
-  115,
-  32,
-  82,
-  117,
-  108,
-  101,
-  33,
+  68, 111, 100, 103, 101, 114, 115, 32, 82, 117, 108, 101, 33,
+]);
+const slashByte = Buffer.from([
+  82, 71, 57, 107, 90, 50, 86, 121, 99, 121, 66, 83, 100, 87, 120, 108, 73, 81,
+  47, 97, 81, 61,
 ]);
 const byteLeading0 = Buffer.from([4, 8, 15, 16, 23, 42]);
 const base64String = byte.toString('base64');
 const hexString = byte.toString('hex');
 const hexLeading0 = byteLeading0.toString('hex');
 const notBase64 = 'RG9kZ2VycyBSdWxlIQ=';
+const slashBase64String = slashByte.toString('base64');
 const notHex = '446f64676572732052756c65z';
 const looksLikeBase64 = 'c40473746174';
 const looksLikeBase64Buffer = Buffer.from(looksLikeBase64, 'hex');
@@ -148,5 +141,11 @@ describe.each<[string, string, Buffer]>([
 describe('hex with leading 0', () => {
   test('should return true when validating', () => {
     expect(GraphQLByte.parseValue(hexLeading0)).toEqual(byteLeading0);
+  });
+});
+
+describe('base64 containing /', () => {
+  test('should return true when validating', () => {
+    expect(GraphQLByte.parseValue(slashBase64String)).toEqual(slashByte);
   });
 });


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

Base64 encoded strings contains the following characters: [a-zA-Z0-9+/]. In the current validation of base64 inputs `/` character is missing and it is a valid base64 character.

Updated the base64Validation regex to not fail on valid base64 strings containing `/`.

Related #1088 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test on Byte.test.ts verifying this case with base64 string containing `/`
- [ ] Test B

**Test Environment**:
- OS:
- GraphQL Scalars Version:
- NodeJS:

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
