### PR TITLE
Improve phone number minimum length validation

### DIFF
--- a/src/scalars/PhoneNumber.ts
+++ b/src/scalars/PhoneNumber.ts
@@ -1,6 +1,6 @@
 import { Kind, GraphQLError, GraphQLScalarType } from 'graphql';
 
-const PHONE_NUMBER_REGEX = /^\+[1-9]\d{1,14}$/;
+const PHONE_NUMBER_REGEX = /^\+[1-9]\d{6,14}$/;
 
 export const GraphQLPhoneNumber: GraphQLScalarType =
   /*#__PURE__*/ new GraphQLScalarType({
@@ -16,7 +16,7 @@ export const GraphQLPhoneNumber: GraphQLScalarType =
 
       if (!PHONE_NUMBER_REGEX.test(value)) {
         throw new TypeError(
-          `Value is not a valid phone number of the form +17895551234 (10-15 digits): ${value}`,
+          `Value is not a valid phone number of the form +17895551234 (7-15 digits): ${value}`,
         );
       }
 
@@ -30,7 +30,7 @@ export const GraphQLPhoneNumber: GraphQLScalarType =
 
       if (!PHONE_NUMBER_REGEX.test(value)) {
         throw new TypeError(
-          `Value is not a valid phone number of the form +17895551234 (10-15 digits): ${value}`,
+          `Value is not a valid phone number of the form +17895551234 (7-15 digits): ${value}`,
         );
       }
 
@@ -46,7 +46,7 @@ export const GraphQLPhoneNumber: GraphQLScalarType =
 
       if (!PHONE_NUMBER_REGEX.test(ast.value)) {
         throw new TypeError(
-          `Value is not a valid phone number of the form +17895551234 (10-15 digits): ${ast.value}`,
+          `Value is not a valid phone number of the form +17895551234 (7-15 digits): ${ast.value}`,
         );
       }
 

--- a/tests/PhoneNumber.test.ts
+++ b/tests/PhoneNumber.test.ts
@@ -32,7 +32,7 @@ describe('PhoneNumber', () => {
         expect(() =>
           GraphQLPhoneNumber.serialize('this is not a phone number'),
         ).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(10-15 digits\)/,
+          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
         );
       });
 
@@ -40,7 +40,7 @@ describe('PhoneNumber', () => {
         expect(() =>
           GraphQLPhoneNumber.parseValue('this is not a phone number'),
         ).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(10-15 digits\)/,
+          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
         );
       });
 
@@ -51,7 +51,7 @@ describe('PhoneNumber', () => {
             {},
           ),
         ).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(10-15 digits\)/,
+          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
         );
       });
     });
@@ -79,7 +79,7 @@ describe('PhoneNumber', () => {
     describe('too long', () => {
       test('serialize', () => {
         expect(() => GraphQLPhoneNumber.serialize('+1789555123456789')).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(10-15 digits\)/,
+          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
         );
       });
 
@@ -87,7 +87,7 @@ describe('PhoneNumber', () => {
         expect(() =>
           GraphQLPhoneNumber.parseValue('+1789555123456789'),
         ).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(10-15 digits\)/,
+          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
         );
       });
 
@@ -98,7 +98,32 @@ describe('PhoneNumber', () => {
             {},
           ),
         ).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(10-15 digits\)/,
+          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
+        );
+      });
+    });
+
+    describe('too small', () => {
+      test('serialize', () => {
+        expect(() => GraphQLPhoneNumber.serialize('+123')).toThrow(
+          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
+        );
+      });
+
+      test('parseValue', () => {
+        expect(() => GraphQLPhoneNumber.parseValue('+123')).toThrow(
+          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
+        );
+      });
+
+      test('parseLiteral', () => {
+        expect(() =>
+          GraphQLPhoneNumber.parseLiteral(
+            { value: '+123', kind: Kind.STRING },
+            {},
+          ),
+        ).toThrow(
+          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
         );
       });
     });
@@ -106,13 +131,13 @@ describe('PhoneNumber', () => {
     describe('no plus sign', () => {
       test('serialize', () => {
         expect(() => GraphQLPhoneNumber.serialize('17895551234')).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(10-15 digits\)/,
+          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
         );
       });
 
       test('parseValue', () => {
         expect(() => GraphQLPhoneNumber.parseValue('17895551234')).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(10-15 digits\)/,
+          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
         );
       });
 
@@ -123,7 +148,7 @@ describe('PhoneNumber', () => {
             {},
           ),
         ).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(10-15 digits\)/,
+          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
         );
       });
     });


### PR DESCRIPTION
## Description

At the moment the phone number regex validates phone numbers with just one digit. Assuming the Niue 7 digits use case is the minimum possible, the regex should be strict on accepting less digits than that.

Related #1190

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Created specific unit tests to validate the change.

**Test Environment**:
- OS: Mac OS
- GraphQL Scalars Version: 1.13.1
- NodeJS: 14.18.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules