### PR TITLE
feat: add jp postal code

### DIFF
--- a/src/scalars/PostalCode.ts
+++ b/src/scalars/PostalCode.ts
@@ -25,6 +25,7 @@ import { Kind, GraphQLError, GraphQLScalarType } from 'graphql';
 // CH - Switzerland
 // LU - Luxembourg
 // IR - Iran
+// JP - Japan
 //
 // This is really a practical decision of weight (of the package) vs. completeness.
 //
@@ -50,7 +51,8 @@ const POSTAL_CODE_REGEXES = [
   /* PT */ /*#__PURE__*//^\d{4}([\-]\d{3})?$/,
   /* CH */ /*#__PURE__*//^\d{4}$/,
   /* LU */ /*#__PURE__*//^\d{4}$/,
-  /* IR */ /*#__PURE__*//^[1,3-9]{10}$/
+  /* IR */ /*#__PURE__*//^[1,3-9]{10}$/,
+  /* JP */ /*#__PURE__*//^\d{3}-\d{4}$/
 ];
 
 function _testPostalCode(postalCode: string) {

--- a/tests/PostalCode.test.ts
+++ b/tests/PostalCode.test.ts
@@ -296,6 +296,25 @@ describe('PostalCode', () => {
         ).toBe('1345678987');
       });
     });
+
+    describe('Japan', () => {
+      test('serialize', () => {
+        expect(GraphQLPostalCode.serialize('123-4567')).toBe('123-4567');
+      });
+
+      test('parseValue', () => {
+        expect(GraphQLPostalCode.parseValue('123-4567')).toBe('123-4567');
+      });
+
+      test('parseLiteral', () => {
+        expect(
+          GraphQLPostalCode.parseLiteral(
+            { value: '123-4567', kind: Kind.STRING },
+            {},
+          ),
+        ).toBe('123-4567');
+      });
+    });
   });
 
   describe('invalid', () => {

--- a/website/docs/scalars/postal-code.md
+++ b/website/docs/scalars/postal-code.md
@@ -23,6 +23,7 @@ Which gives us the following countries:
 - BE - Belgium
 - IN - India
 - IR - Iran
+- JP - Japan
 
 This is really a practical decision of weight (of the package) vs. completeness.
 


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

This PR will add the proper regex check for Japan postalCode format in scalars.

ref: https://japan-postcode.810popo.net/

>ZIP codes of Japan are represented by 7 digits numbers using the format 〒NNN-NNNN, where 〒 is the Japanese postal code mark and N is a digit.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:
- OS: macOS Monterey
- GraphQL Scalars Version: 1.14.1
- NodeJS: v16.13.2

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
