### PR TITLE
feat: Add Banking Routing Number

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ import {
   GraphQLCountryCode,
   GraphQLLocale,
   GraphQLRoutingNumber,
+  GraphQLAccountNumber,
 } from './scalars';
 import { GraphQLDuration } from './scalars/iso-date/Duration';
 
@@ -115,6 +116,7 @@ export {
   CountryCode as CountryCodeDefinition,
   Locale as LocaleDefinition,
   RoutingNumber as RoutingNumberDefinition,
+  AccountNumber as AccountNumberDefinition,
 } from './typeDefs';
 
 export { typeDefs } from './typeDefs';
@@ -176,6 +178,7 @@ export {
   GraphQLCountryCode as CountryCodeResolver,
   GraphQLLocale as LocaleResolver,
   GraphQLRoutingNumber as RoutingNumberResolver,
+  GraphQLAccountNumber as AccountNumberResolver,
 };
 
 export const resolvers: Record<string, GraphQLScalarType> = {
@@ -235,6 +238,7 @@ export const resolvers: Record<string, GraphQLScalarType> = {
   CountryCode: GraphQLCountryCode,
   Locale: GraphQLLocale,
   RoutingNumber: GraphQLRoutingNumber,
+  AccountNumber: GraphQLAccountNumber,
 };
 
 export {
@@ -294,6 +298,7 @@ export {
   CountryCode as CountryCodeMock,
   Locale as LocaleMock,
   RoutingNumber as RoutingNumberMock,
+  AccountNumber as AccountNumberMock,
 } from './mocks';
 
 export { mocks };
@@ -361,4 +366,5 @@ export {
   GraphQLCountryCode,
   GraphQLLocale,
   GraphQLRoutingNumber,
+  GraphQLAccountNumber,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ import {
   GraphQLDID,
   GraphQLCountryCode,
   GraphQLLocale,
+  GraphQLRoutingNumber,
 } from './scalars';
 import { GraphQLDuration } from './scalars/iso-date/Duration';
 
@@ -113,6 +114,7 @@ export {
   DID as DIDDefinition,
   CountryCode as CountryCodeDefinition,
   Locale as LocaleDefinition,
+  RoutingNumber as RoutingNumberDefinition,
 } from './typeDefs';
 
 export { typeDefs } from './typeDefs';
@@ -173,6 +175,7 @@ export {
   GraphQLDID as DIDResolver,
   GraphQLCountryCode as CountryCodeResolver,
   GraphQLLocale as LocaleResolver,
+  GraphQLRoutingNumber as RoutingNumberResolver,
 };
 
 export const resolvers: Record<string, GraphQLScalarType> = {
@@ -231,6 +234,7 @@ export const resolvers: Record<string, GraphQLScalarType> = {
   DID: GraphQLDID,
   CountryCode: GraphQLCountryCode,
   Locale: GraphQLLocale,
+  RoutingNumber: GraphQLRoutingNumber,
 };
 
 export {
@@ -289,6 +293,7 @@ export {
   DID as DIDMock,
   CountryCode as CountryCodeMock,
   Locale as LocaleMock,
+  RoutingNumber as RoutingNumberMock,
 } from './mocks';
 
 export { mocks };
@@ -355,4 +360,5 @@ export {
   GraphQLDID,
   GraphQLCountryCode,
   GraphQLLocale,
+  GraphQLRoutingNumber,
 };

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -116,6 +116,7 @@ export const SafeInt = () => Number.MAX_SAFE_INTEGER;
 export const DID = () => 'did:example:123456789abcdefghi';
 export const CountryCode = () => 'US';
 export const Locale = () => 'zh-cmn-Hans-CN';
+export const RoutingNumber = () => '111000025';
 
 export {
   DateMock as Date,

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -117,6 +117,7 @@ export const DID = () => 'did:example:123456789abcdefghi';
 export const CountryCode = () => 'US';
 export const Locale = () => 'zh-cmn-Hans-CN';
 export const RoutingNumber = () => '111000025';
+export const AccountNumber = () => '000000012345';
 
 export {
   DateMock as Date,

--- a/src/scalars/AccountNumber.ts
+++ b/src/scalars/AccountNumber.ts
@@ -1,0 +1,62 @@
+import {
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig,
+  Kind,
+  locatedError,
+} from 'graphql';
+
+interface Validator {
+  (rtn: string): boolean;
+}
+
+const validator: Validator = (rtn) => /^([a-zA-Z0-9]){5,17}$/.test(rtn);
+
+const validate = (account: unknown): string => {
+  if (typeof account !== 'string') {
+    throw locatedError(new TypeError('can only parse String'), null);
+  }
+
+  if (!validator(account)) {
+    throw locatedError(
+      new TypeError('must be alphanumeric between 5-17'),
+      null,
+    );
+  }
+
+  return account;
+};
+
+export const GraphQLAccountNumberConfig: GraphQLScalarTypeConfig<
+  string,
+  string
+> = {
+  name: 'AccountNumber',
+  description:
+    'Banking account number is a string of 5 to 17 alphanumeric values for ' +
+    'representing an generic account number',
+
+  serialize(value: unknown) {
+    return validate(value);
+  },
+
+  parseValue(value: unknown) {
+    return validate(value);
+  },
+
+  parseLiteral(ast) {
+    if (ast.kind === Kind.STRING) {
+      return validate(ast.value);
+    }
+
+    throw locatedError(
+      new TypeError(
+        `Account Number can only parse String but got '${ast.kind}'`,
+      ),
+      ast,
+    );
+  },
+};
+
+export const GraphQLAccountNumber = new GraphQLScalarType(
+  GraphQLAccountNumberConfig,
+);

--- a/src/scalars/RoutingNumber.ts
+++ b/src/scalars/RoutingNumber.ts
@@ -1,0 +1,101 @@
+import {
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig,
+  Kind,
+  locatedError,
+} from 'graphql';
+
+interface Validator {
+  (rtn: string): boolean;
+}
+
+const routingNumber = (rtn: number | string) => '' + rtn;
+
+const haveNineDigits: Validator = (rtn) => /^\d{9}$/.test(rtn);
+
+/**
+ * Calculates checksum for MIRC format XXXXYYYYC where C is the check digit
+ *
+ * The checksum is position-weighted sum of each of the digits. So, given the
+ * routing number `031001175`, which The last digit (5 in the example), is the
+ * check digit. The calculation is given in terms of the eight first digits:
+ *
+ * 0    3   1   0   0   1   1   7
+ *                x
+ * 3    7   1   3   7   1   3   7
+ * ____________________________________
+ * 0 + 21 + 1 + 0 + 0 + 1 + 3 + 49 = 75
+ * ____________________________________
+ * 75 + 5 (check digit) = 80 (Must multiple of 10)
+ */
+const checksum: Validator = (rtn) => {
+  const weight = [3, 7, 1];
+  const accumulator = (acc: number, curr: number): number => acc + curr;
+
+  const digits = rtn.split('').map((digit) => Number.parseInt(digit, 10));
+  const checkDigit = digits.pop();
+
+  const sum = digits
+    .map((digit, index) => digit * weight[index % 3])
+    .reduce(accumulator, 0);
+
+  return (sum + checkDigit) % 10 === 0;
+};
+
+const validate = (value: unknown) => {
+  if (
+    typeof value !== 'string' &&
+    !(typeof value === 'number' && Number.isInteger(value))
+  ) {
+    throw locatedError(new TypeError('must be integer or string'), null);
+  }
+
+  const rtn = routingNumber(value);
+
+  if (!haveNineDigits(rtn)) {
+    throw new TypeError('must have nine digits');
+  }
+
+  if (!checksum(rtn)) {
+    throw new TypeError("checksum doens't match");
+  }
+
+  return rtn;
+};
+
+export const GraphQLRoutingNumberConfig: GraphQLScalarTypeConfig<
+  string,
+  string
+> = {
+  name: 'RoutingNumber',
+  description:
+    'In the US, an ABA routing transit number (`ABA RTN`) is a nine-digit ' +
+    'code to identify the financial institution.',
+
+  specifiedByURL: 'https://en.wikipedia.org/wiki/ABA_routing_transit_number',
+
+  serialize(value: unknown) {
+    return validate(value);
+  },
+
+  parseValue(value: unknown) {
+    return validate(value);
+  },
+
+  parseLiteral(ast) {
+    if (ast.kind === Kind.INT || ast.kind === Kind.STRING) {
+      return validate(ast.value);
+    }
+
+    throw locatedError(
+      new TypeError(
+        `ABA Routing Transit Number can only parse Integer or String but got '${ast.kind}'`,
+      ),
+      ast,
+    );
+  },
+};
+
+export const GraphQLRoutingNumber = new GraphQLScalarType(
+  GraphQLRoutingNumberConfig,
+);

--- a/src/scalars/index.ts
+++ b/src/scalars/index.ts
@@ -52,3 +52,4 @@ export { GraphQLVoid } from './Void';
 export { GraphQLDID } from './DID';
 export { GraphQLCountryCode } from './CountryCode';
 export { GraphQLLocale } from './Locale';
+export { GraphQLRoutingNumber } from './RoutingNumber';

--- a/src/scalars/index.ts
+++ b/src/scalars/index.ts
@@ -53,3 +53,4 @@ export { GraphQLDID } from './DID';
 export { GraphQLCountryCode } from './CountryCode';
 export { GraphQLLocale } from './Locale';
 export { GraphQLRoutingNumber } from './RoutingNumber';
+export { GraphQLAccountNumber } from './AccountNumber';

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -45,6 +45,7 @@ export const URL = 'scalar URL';
 export const USCurrency = `scalar USCurrency`;
 export const Currency = `scalar Currency`;
 export const RoutingNumber = 'scalar RoutingNumber';
+export const AccountNumber = 'scalar AccountNumber';
 
 export const UnsignedFloat = 'scalar UnsignedFloat';
 export const UnsignedInt = 'scalar UnsignedInt';
@@ -114,4 +115,5 @@ export const typeDefs = [
   CountryCode,
   Locale,
   RoutingNumber,
+  AccountNumber,
 ];

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -44,6 +44,7 @@ export const SafeInt = `scalar SafeInt`;
 export const URL = 'scalar URL';
 export const USCurrency = `scalar USCurrency`;
 export const Currency = `scalar Currency`;
+export const RoutingNumber = 'scalar RoutingNumber';
 
 export const UnsignedFloat = 'scalar UnsignedFloat';
 export const UnsignedInt = 'scalar UnsignedInt';
@@ -112,4 +113,5 @@ export const typeDefs = [
   DID,
   CountryCode,
   Locale,
+  RoutingNumber,
 ];

--- a/tests/AccountNumber.test.ts
+++ b/tests/AccountNumber.test.ts
@@ -1,0 +1,64 @@
+import { GraphQLAccountNumber } from '../src/scalars/AccountNumber';
+import { Kind } from 'graphql';
+
+const invalids = [
+  ['greather than 17', '123456789123456789'],
+  ['less than 5', '1234'],
+  ['special character', '1234a$'],
+  ['special character', '12345_'],
+];
+
+const valids: string[] = ['01234', 'a1234', '12345678912345678'];
+
+describe('ABA Routing Number', () => {
+  describe('invalid', () => {
+    test("type isn't String", () => {
+      const value = 102;
+
+      expect(() =>
+        GraphQLAccountNumber.parseLiteral({
+          kind: Kind.INT,
+          value: '' + value,
+        }),
+      ).toThrow(/can only parse String/);
+
+      expect(() => GraphQLAccountNumber.serialize(value)).toThrow(
+        /can only parse String/,
+      );
+
+      expect(() => GraphQLAccountNumber.parseValue(value)).toThrow(
+        /can only parse String/,
+      );
+    });
+
+    test.each(invalids)(`%s`, (_, routingNumber) => {
+      expect(() =>
+        GraphQLAccountNumber.parseLiteral({
+          kind: Kind.STRING,
+          value: routingNumber,
+        }),
+      ).toThrow(/must be alphanumeric between 5-17/);
+
+      expect(() => GraphQLAccountNumber.parseValue(routingNumber)).toThrow(
+        /must be alphanumeric between 5-17/,
+      );
+
+      expect(() => GraphQLAccountNumber.serialize(routingNumber)).toThrow(
+        /must be alphanumeric between 5-17/,
+      );
+    });
+  });
+
+  describe('valid', () => {
+    test.each(valids)('scalar: %s', (routing) => {
+      expect(GraphQLAccountNumber.parseValue(routing)).toBe(routing);
+      expect(GraphQLAccountNumber.serialize(routing)).toBe(routing);
+      expect(
+        GraphQLAccountNumber.parseLiteral({
+          kind: Kind.STRING,
+          value: routing,
+        }),
+      ).toBe(routing);
+    });
+  });
+});

--- a/tests/RoutingNumber.test.ts
+++ b/tests/RoutingNumber.test.ts
@@ -1,0 +1,72 @@
+import { GraphQLRoutingNumber } from '../src/scalars/RoutingNumber';
+import { Kind } from 'graphql';
+
+const invalids: [string, string, string | RegExp][] = [
+  ['less than 9 digits', '11100009', /must have nine digits/],
+  ['greather than 9 digits', '1110000250', /must have nine digits/],
+  ["checksum doens't match", '111000024', /checksum doens't match/],
+  ["all 1's", '111111111', /checksum doens't match/],
+  ['special character', '11100002$', /must have nine digits/],
+  ['alphabetic character', '11100002a', /must have nine digits/],
+];
+
+const valids: (string | number)[] = [
+  '111000025',
+  111000025,
+  '031001175',
+  '021000021',
+];
+
+describe('ABA Routing Number', () => {
+  describe('invalid', () => {
+    test("type isn't String or Integer", () => {
+      const value = 102.3;
+
+      expect(() =>
+        GraphQLRoutingNumber.parseLiteral({
+          kind: Kind.FLOAT,
+          value: '' + value,
+        }),
+      ).toThrow(/can only parse Integer or String/);
+
+      expect(() => GraphQLRoutingNumber.serialize(value)).toThrow(
+        /must be integer or string/,
+      );
+
+      expect(() => GraphQLRoutingNumber.parseValue(value)).toThrow(
+        /must be integer or string/,
+      );
+    });
+
+    test.each(invalids)(`%s`, (_, routingNumber, reason) => {
+      expect(() =>
+        GraphQLRoutingNumber.parseLiteral({
+          kind: Kind.STRING,
+          value: routingNumber,
+        }),
+      ).toThrow(reason);
+
+      expect(() => GraphQLRoutingNumber.parseValue(routingNumber)).toThrow(
+        reason,
+      );
+
+      expect(() => GraphQLRoutingNumber.serialize(routingNumber)).toThrow(
+        reason,
+      );
+    });
+  });
+
+  describe('valid', () => {
+    test.each(valids)('scalar: %s', (routing) => {
+      const parsed = '' + routing;
+      expect(GraphQLRoutingNumber.parseValue(routing)).toBe(parsed);
+      expect(GraphQLRoutingNumber.serialize(routing)).toBe(parsed);
+      expect(
+        GraphQLRoutingNumber.parseLiteral({
+          kind: Kind.STRING,
+          value: '' + routing,
+        }),
+      ).toBe(parsed);
+    });
+  });
+});

--- a/tests/RoutingNumber.test.ts
+++ b/tests/RoutingNumber.test.ts
@@ -1,13 +1,14 @@
 import { GraphQLRoutingNumber } from '../src/scalars/RoutingNumber';
 import { Kind } from 'graphql';
 
-const invalids: [string, string, string | RegExp][] = [
+const invalids: [string, string | number, RegExp][] = [
   ['less than 9 digits', '11100009', /must have nine digits/],
   ['greather than 9 digits', '1110000250', /must have nine digits/],
   ["checksum doens't match", '111000024', /checksum doens't match/],
   ["all 1's", '111111111', /checksum doens't match/],
   ['special character', '11100002$', /must have nine digits/],
   ['alphabetic character', '11100002a', /must have nine digits/],
+  ['negative number', -111000025, /must have nine digits/],
 ];
 
 const valids: (string | number)[] = [
@@ -41,8 +42,8 @@ describe('ABA Routing Number', () => {
     test.each(invalids)(`%s`, (_, routingNumber, reason) => {
       expect(() =>
         GraphQLRoutingNumber.parseLiteral({
-          kind: Kind.STRING,
-          value: routingNumber,
+          kind: typeof routingNumber === 'string' ? Kind.STRING : Kind.INT,
+          value: '' + routingNumber,
         }),
       ).toThrow(reason);
 

--- a/website/docs/scalars/account-number.md
+++ b/website/docs/scalars/account-number.md
@@ -1,0 +1,7 @@
+---
+id: routing-number
+title: RoutingNumber
+sidebar_label: RoutingNumber
+---
+
+Account number represents a generic banking account in US. They don't live by any rule, except each bank can have 5 to 17 alphanumeric caracters with private validity.

--- a/website/docs/scalars/account-number.md
+++ b/website/docs/scalars/account-number.md
@@ -1,7 +1,7 @@
 ---
-id: routing-number
-title: RoutingNumber
-sidebar_label: RoutingNumber
+id: account-number
+title: Account Number
+sidebar_label: Account Number
 ---
 
 Account number represents a generic banking account in US. They don't live by any rule, except each bank can have 5 to 17 alphanumeric caracters with private validity.

--- a/website/docs/scalars/routing-number.md
+++ b/website/docs/scalars/routing-number.md
@@ -1,0 +1,7 @@
+---
+id: routing-number
+title: RoutingNumber
+sidebar_label: RoutingNumber
+---
+
+An field whose in the US is an [ABA routing transit number](https://en.wikipedia.org/wiki/ABA_routing_transit_number)(`ABA RTN`) is a nine-digit code to identify the financial institution.


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

This PR don't require any additional dependency. They are used to validate using checksum, when required, a few banking number types. Account Number spec is Bank dependent and its validity is kept private in US. They can have 5-17 alphanumeric string:

- [x] Routing transit number - [ABA routing transit number](https://en.wikipedia.org/wiki/ABA_routing_transit_number)
- [x] Account number
- [x] Check number


Related #1121 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

For ABA Routing Number i checked, the so called, MICR Routing Number format, which is a 9 digit and the last is the check digit.

### Routing Number
- [ ] 7 digit number
- [ ] 10 digit number
- [ ] special and non-digit characters
- [ ] checksum

Account number is 5-17 alphanumeric string
### Account Number
- [ ] special characters
- [ ] alphanumeric string between 5-17

**Test Environment**:
- OS: MacOS Catalina (`12.1`)
- GraphQL Scalars Version: `1.14.0`
- NodeJS: `16.13.2`

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
`Check number`, imho can be represented as `UnsignedInt`. They are issued by the Bank and can be as long as they can and are sequentially assigned. As mentioned above, bank `account number` in this context is represented by private Bank system without checksum, in case for international account number already exists a scalar for it like the `IBAN`
