### PR TITLE
fix(ts): Add types to exports fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
     },
     "./*": {
       "require": "./dist/*.js",
-      "import": "./dist/*.mjs"
+      "import": "./dist/*.mjs",
+      "types": "./dist/*.d.ts"
     }
   },
   "license": "MIT",


### PR DESCRIPTION
## Description

Fix #1602 

See https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing for more details.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
