### PR TITLE
feat: add Cuid scalar #756

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ import {
   GraphQLLocale,
   GraphQLRoutingNumber,
   GraphQLAccountNumber,
+  GraphQLCuid,
 } from './scalars';
 import { GraphQLDuration } from './scalars/iso-date/Duration';
 
@@ -119,6 +120,7 @@ export {
   Locale as LocaleDefinition,
   RoutingNumber as RoutingNumberDefinition,
   AccountNumber as AccountNumberDefinition,
+  Cuid as CuidDefinition,
 } from './typeDefs';
 
 export { typeDefs } from './typeDefs';
@@ -182,6 +184,7 @@ export {
   GraphQLLocale as LocaleResolver,
   GraphQLRoutingNumber as RoutingNumberResolver,
   GraphQLAccountNumber as AccountNumberResolver,
+  GraphQLCuid as CuidResolver,
 };
 
 export const resolvers: Record<string, GraphQLScalarType> = {
@@ -243,6 +246,7 @@ export const resolvers: Record<string, GraphQLScalarType> = {
   Locale: GraphQLLocale,
   RoutingNumber: GraphQLRoutingNumber,
   AccountNumber: GraphQLAccountNumber,
+  Cuid: GraphQLCuid,
 };
 
 export {
@@ -304,6 +308,7 @@ export {
   Locale as LocaleMock,
   RoutingNumber as RoutingNumberMock,
   AccountNumber as AccountNumberMock,
+  Cuid as CuidMock,
 } from './mocks';
 
 export { mocks };
@@ -373,4 +378,5 @@ export {
   GraphQLLocale,
   GraphQLRoutingNumber,
   GraphQLAccountNumber,
+  GraphQLCuid,
 };

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -119,6 +119,7 @@ export const CountryCode = () => 'US';
 export const Locale = () => 'zh-cmn-Hans-CN';
 export const RoutingNumber = () => '111000025';
 export const AccountNumber = () => '000000012345';
+export const Cuid = () => 'cjld2cyuq0000t3rmniod1foy';
 
 export {
   DateMock as Date,

--- a/src/scalars/Cuid.ts
+++ b/src/scalars/Cuid.ts
@@ -1,0 +1,52 @@
+import {
+  Kind,
+  GraphQLError,
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig,
+} from 'graphql';
+
+const validate = (value: any) => {
+  const CUID_REGEX = /^c[^\s-]{8,}$/i;
+
+  if (typeof value !== 'string') {
+    throw new TypeError(`Value is not string: ${value}`);
+  }
+
+  if (!CUID_REGEX.test(value)) {
+    throw new TypeError(`Value is not a valid cuid: ${value}`);
+  }
+
+  return value;
+};
+
+const specifiedByURL = 'https://github.com/ericelliott/cuid#broken-down';
+
+export const GraphQLCuidConfig = /*#__PURE__*/ {
+  name: 'Cuid',
+
+  description:
+    'A field whose value conforms to the standard cuid format as specified in https://github.com/ericelliott/cuid#broken-down',
+
+  serialize: validate,
+
+  parseValue: validate,
+
+  parseLiteral(ast) {
+    if (ast.kind !== Kind.STRING) {
+      throw new GraphQLError(
+        `Can only validate strings as cuids but got a: ${ast.kind}`,
+      );
+    }
+
+    return validate(ast.value);
+  },
+
+  specifiedByURL,
+  specifiedByUrl: specifiedByURL,
+  extensions: {
+    codegenScalarType: 'string',
+  },
+} as GraphQLScalarTypeConfig<string, string>;
+
+export const GraphQLCuid: GraphQLScalarType =
+  /*#__PURE__*/ new GraphQLScalarType(GraphQLCuidConfig);

--- a/src/scalars/index.ts
+++ b/src/scalars/index.ts
@@ -55,3 +55,4 @@ export { GraphQLCountryCode } from './CountryCode';
 export { GraphQLLocale } from './Locale';
 export { GraphQLRoutingNumber } from './RoutingNumber';
 export { GraphQLAccountNumber } from './AccountNumber';
+export { GraphQLCuid } from './Cuid';

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -47,6 +47,7 @@ export const USCurrency = `scalar USCurrency`;
 export const Currency = `scalar Currency`;
 export const RoutingNumber = 'scalar RoutingNumber';
 export const AccountNumber = 'scalar AccountNumber';
+export const Cuid = 'scalar Cuid';
 
 export const UnsignedFloat = 'scalar UnsignedFloat';
 export const UnsignedInt = 'scalar UnsignedInt';
@@ -118,4 +119,5 @@ export const typeDefs = [
   Locale,
   RoutingNumber,
   AccountNumber,
+  Cuid,
 ];

--- a/tests/Cuid.test.ts
+++ b/tests/Cuid.test.ts
@@ -1,0 +1,78 @@
+/* global describe, test, expect */
+
+import { Kind } from 'graphql/language';
+import { GraphQLCuid } from '../src/scalars/Cuid';
+
+describe('Cuid', () => {
+  describe('valid', () => {
+    test('serialize', () => {
+      expect(GraphQLCuid.serialize('cjld2cyuq0000t3rmniod1foy')).toBe(
+        'cjld2cyuq0000t3rmniod1foy',
+      );
+    });
+
+    test('parseValue', () => {
+      expect(GraphQLCuid.parseValue('cjld2cyuq0000t3rmniod1foy')).toBe(
+        'cjld2cyuq0000t3rmniod1foy',
+      );
+    });
+
+    test('parseLiteral', () => {
+      expect(
+        GraphQLCuid.parseLiteral(
+          {
+            value: 'cjld2cyuq0000t3rmniod1foy',
+            kind: Kind.STRING,
+          },
+          {},
+        ),
+      ).toBe('cjld2cyuq0000t3rmniod1foy');
+    });
+  });
+
+  describe('invalid', () => {
+    describe('not a cuid', () => {
+      test('serialize', () => {
+        expect(() => GraphQLCuid.serialize('this is not a cuid')).toThrow(
+          /Value is not a valid cuid/,
+        );
+      });
+
+      test('parseValue', () => {
+        expect(() => GraphQLCuid.parseValue('this is not a cuid')).toThrow(
+          /Value is not a valid cuid/,
+        );
+      });
+
+      test('parseLiteral', () => {
+        expect(() =>
+          GraphQLCuid.parseLiteral(
+            {
+              value: 'this is not a cuid',
+              kind: Kind.STRING,
+            },
+            {},
+          ),
+        ).toThrow(/Value is not a valid cuid/);
+      });
+    });
+
+    describe('not a string', () => {
+      test('serialize', () => {
+        expect(() => GraphQLCuid.serialize(123)).toThrow(/Value is not string/);
+      });
+
+      test('parseValue', () => {
+        expect(() => GraphQLCuid.parseValue(123)).toThrow(
+          /Value is not string/,
+        );
+      });
+
+      test('parseLiteral', () => {
+        expect(() =>
+          GraphQLCuid.parseLiteral({ value: '123', kind: Kind.INT }, {}),
+        ).toThrow(/Can only validate strings as cuids but got a/);
+      });
+    });
+  });
+});

--- a/website/docs/scalars/cuid.mdx
+++ b/website/docs/scalars/cuid.mdx
@@ -1,0 +1,8 @@
+---
+id: cuid
+title: Cuid
+sidebar_label: Cuid
+---
+
+A field whose value conforms to the standard cuid format as specified in
+[This Repo](https://github.com/ericelliott/cuid#broken-down).


### PR DESCRIPTION
## Description

This PR implements a `Cuid` scalar as requested in #756. I also found myself wanting a `Cuid` scalar, so figured i'd try adding one here.

Related #756
Closes #756  

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Added unit tests for `Cuid` that test all available apis.

**Test Environment**:
- OS: `linux-gnu`
- GraphQL Scalars Version: `1.17.0`
- NodeJS: `16.15.1`

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
