### PR TITLE
fix: corrects the date codegen scalar return types

### DIFF
--- a/src/scalars/iso-date/Date.ts
+++ b/src/scalars/iso-date/Date.ts
@@ -71,7 +71,7 @@ export const GraphQLDateConfig: GraphQLScalarTypeConfig<Date, string> =
       );
     },
     extensions: {
-      codegenScalarType: 'Date | string',
+      codegenScalarType: 'Date',
     },
   };
 

--- a/src/scalars/iso-date/DateTime.ts
+++ b/src/scalars/iso-date/DateTime.ts
@@ -93,7 +93,7 @@ export const GraphQLDateTimeConfig: GraphQLScalarTypeConfig<Date, Date> =
       );
     },
     extensions: {
-      codegenScalarType: 'Date | string',
+      codegenScalarType: 'Date',
     },
   };
 

--- a/src/scalars/iso-date/Time.ts
+++ b/src/scalars/iso-date/Time.ts
@@ -81,7 +81,7 @@ const config: GraphQLScalarTypeConfig<Date, string> = {
     );
   },
   extensions: {
-    codegenScalarType: 'Date | string',
+    codegenScalarType: 'Date',
   },
 };
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/Urigo/graphql-scalars/issues/1657

It's my understanding that these iso-date serialisers will throw in the event that they do no deserialise a date correctly. As such, their codegen type definition should reflect this.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

This is not a functionality test so I have not added any tests. Existing tests completed happily.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
