### PR TITLE
fix: validation of dates < 1000

### DIFF
--- a/src/scalars/iso-date/validator.ts
+++ b/src/scalars/iso-date/validator.ts
@@ -73,7 +73,7 @@ export const validateTime = (time: string): boolean => {
 // 12            December             31
 //
 export const validateDate = (datestring: string): boolean => {
-  const RFC_3339_REGEX = /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))$/;
+  const RFC_3339_REGEX = /^(\d{1,4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))$/;
 
   if (!RFC_3339_REGEX.test(datestring)) {
     return false;


### PR DESCRIPTION
The date validation currently falls for dates with years smaller 1000, because the trailing zeros get cut and the regular expression expect exactly 4 digits for years. Instead with this Pull Request I recommend a range of at least 1 and at most 4 digits for the validation of the year component in dates.

Validating the date 0001-01-01 in the current implementation
```
const validateDate = (datestring) => {
    const RFC_3339_REGEX = /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))$/;

    if (!RFC_3339_REGEX.test(datestring)) {
        console.error({ dateString: datestring, 'date validation': RFC_3339_REGEX.test(datestring) })
        return false;
    }
    // Verify the correct number of days for
    // the month contained in the date-string.
    const year = Number(datestring.substr(0, 4));
    const month = Number(datestring.substr(5, 2));
    const day = Number(datestring.substr(8, 2));
    switch (month) {
        case 2: // February
            if (leapYear(year) && day > 29) {
                return false;
            }
            else if (!leapYear(year) && day > 28) {
                return false;
            }
            return true;
        case 4: // April
        case 6: // June
        case 9: // September
        case 11: // November
            if (day > 30) {
                return false;
            }
            break;
    }
    return true;
};
```

resulted in the following error
```
{
  "dateString": "01-01-01",
  "date validation": false
}
```