### PR TITLE
fix: add types reference to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
     },
     "./*": {
       "require": "./dist/*.js",
-      "import": "./dist/*.mjs"
+      "import": "./dist/*.mjs",
+      "types": "./dist/*.d.ts"
     }
   },
   "license": "MIT",


### PR DESCRIPTION
I'm having issues with types not working. Not sure why, but adding `"types"` fixes it.

My setup is based on [create-bjerk-typescript](https://github.com/bjerkio/create-bjerk-typescript) which uses Typescript 4.7 and ESM (/w `"module"`).

re: https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#packagejson-exports-imports-and-self-referencing