### PR TITLE
Update docs to clarify that `GraphQLDate` inputs are marshalled as `Date` objects

### DIFF
--- a/website/src/pages/docs/scalars/date.mdx
+++ b/website/src/pages/docs/scalars/date.mdx
@@ -12,5 +12,5 @@ JavaScript Date instances are coerced to an RFC 3339 compliant date string. Inva
 
 ## Input Coercion
 
-When expected as an input type, only RFC 3339 compliant date strings are accepted. All other input values raise a query
+When expected as an input type, only RFC 3339 compliant date strings are accepted, and are coerced to `Date` objects. All other input values raise a query
 error indicating an incorrect type.

--- a/website/src/pages/docs/scalars/date.mdx
+++ b/website/src/pages/docs/scalars/date.mdx
@@ -12,5 +12,5 @@ JavaScript Date instances are coerced to an RFC 3339 compliant date string. Inva
 
 ## Input Coercion
 
-When expected as an input type, only RFC 3339 compliant date strings are accepted, and are coerced to `Date` objects. All other input values raise a query
+When expected as an input type, only RFC 3339 compliant date strings are accepted, and are parsed into `Date` objects. All other input values raise a query
 error indicating an incorrect type.


### PR DESCRIPTION
## Description

Date docs seem to imply that input `GraphQLDate` values come through as strings, but they are in fact parsed into `Date` objects, interpreted as UTC. This can be very confusing, when the `Date` representation converts `'2022-09-29'` becomes the `Date` equivalent of `'2022-09-29T00:00:00.000Z'`, which then (depending on time-of-day and your time-zone), can become `Wed Sep 28 2022 17:00:00 GMT-0700 (Pacific Daylight Time)`.

This PR is simply a documentation update, to clarify that these dates are not passed through transparently as strings, but are instead converted to `Date` objects.

## Type of change

- [x] Documentation update

## How Has This Been Tested?

Documentation update.
## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules