### PR TITLE
feat: Expand the DID scalar regex to accommodate did:pkh

### DIFF
--- a/.changeset/curly-pugs-shave.md
+++ b/.changeset/curly-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+'graphql-scalars': patch
+---
+
+Expand the DID scalar regex to accommodate did:pkh

--- a/src/scalars/DID.ts
+++ b/src/scalars/DID.ts
@@ -2,7 +2,8 @@ import { GraphQLScalarType, Kind, GraphQLScalarTypeConfig, ASTNode } from 'graph
 import { createGraphQLError } from '../error.js';
 
 // See: https://www.w3.org/TR/2021/PR-did-core-20210803/#did-syntax
-const DID_REGEX = /^did:[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+:[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+$/;
+const DID_REGEX =
+  /^did:[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+:[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]*:?[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]*:?[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]*$/;
 
 const validate = (value: any, ast?: ASTNode) => {
   if (typeof value !== 'string') {

--- a/tests/DID.test.ts
+++ b/tests/DID.test.ts
@@ -3,7 +3,7 @@ import { Kind } from 'graphql/language';
 import { GraphQLDID } from '../src/scalars/DID.js';
 
 describe('DID', () => {
-  describe('valid - DID', () => {
+  describe('valid - DID example', () => {
     test('serialize', () => {
       expect(GraphQLDID.serialize('did:example:123456789abcdefghi')).toBe('did:example:123456789abcdefghi');
     });
@@ -16,6 +16,29 @@ describe('DID', () => {
       expect(GraphQLDID.parseLiteral({ value: 'did:example:123456789abcdefghi', kind: Kind.STRING }, {})).toEqual(
         'did:example:123456789abcdefghi'
       );
+    });
+  });
+
+  describe('valid - DID pkh', () => {
+    test('serialize', () => {
+      expect(GraphQLDID.serialize('did:pkh:eip155:1:0x6317FBFf7a0A016eD485fc33f4Ae55F91C403377')).toBe(
+        'did:pkh:eip155:1:0x6317FBFf7a0A016eD485fc33f4Ae55F91C403377'
+      );
+    });
+
+    test('parseValue', () => {
+      expect(GraphQLDID.parseValue('did:pkh:eip155:1:0x6317FBFf7a0A016eD485fc33f4Ae55F91C403377')).toEqual(
+        'did:pkh:eip155:1:0x6317FBFf7a0A016eD485fc33f4Ae55F91C403377'
+      );
+    });
+
+    test('parseLiteral', () => {
+      expect(
+        GraphQLDID.parseLiteral(
+          { value: 'did:pkh:eip155:1:0x6317FBFf7a0A016eD485fc33f4Ae55F91C403377', kind: Kind.STRING },
+          {}
+        )
+      ).toEqual('did:pkh:eip155:1:0x6317FBFf7a0A016eD485fc33f4Ae55F91C403377');
     });
   });
 


### PR DESCRIPTION
## Description

[did:pkh](https://github.com/w3c-ccg/did-pkh/blob/main/did-pkh-method-draft.md) is a widely used method and should be captured by the regex

(issue #1800)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added test cases for a did:pkh string

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

