### PR TITLE
Clarify date parsing/formatting behaviour for non-utc TZs

### DIFF
--- a/website/src/pages/docs/scalars/date.mdx
+++ b/website/src/pages/docs/scalars/date.mdx
@@ -8,9 +8,16 @@ timeline.
 
 ## Result Coercion
 
-JavaScript Date instances are coerced to an RFC 3339 compliant date string. Invalid Date instances raise a field error.
+JavaScript Date instances are coerced to an RFC 3339 compliant date string, taken at the UTC timezone. Invalid Date 
+instances raise a field error.
+
+Examples:
+```
+new Date("2023-02-03T01:00:00Z") -> 2023-02-03
+new Date("2023-02-03T01:00:00+0500") -> 2023-02-02
+```
 
 ## Input Coercion
 
-When expected as an input type, only RFC 3339 compliant date strings are accepted, and are parsed into `Date` objects. All other input values raise a query
-error indicating an incorrect type.
+When expected as an input type, only RFC 3339 compliant date strings are accepted, and are parsed into `Date` objects 
+at midnight UTC. All other input values raise a query error indicating an incorrect type. 


### PR DESCRIPTION
## Description

Since JS `Date` instances carry a time and timezone component, it's ambigious to what date (without time) they correspond. There's also no concensus between libraries dealing with dates: some use UTC (🥳), others use the local timezone (😡). 

Since it's not necessarily obvious from the outside which approach graphql-scalars use, it's useful to have it explicitely documented. 

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
-
