### PR TITLE
feat: add ua postal code

### DIFF
--- a/.changeset/silly-tigers-change.md
+++ b/.changeset/silly-tigers-change.md
@@ -1,0 +1,5 @@
+---
+'graphql-scalars': patch
+---
+
+Support UA postal code in PostalCode scalar

--- a/src/scalars/PostalCode.ts
+++ b/src/scalars/PostalCode.ts
@@ -27,6 +27,7 @@ import { createGraphQLError } from '../error.js';
 // LU - Luxembourg
 // IR - Iran
 // JP - Japan
+// UA - Ukraine
 //
 // This is really a practical decision of weight (of the package) vs. completeness.
 //
@@ -53,7 +54,8 @@ const POSTAL_CODE_REGEXES = [
   /* CH */ /*#__PURE__*//^\d{4}$/,
   /* LU */ /*#__PURE__*//^\d{4}$/,
   /* IR */ /*#__PURE__*//^[1,3-9]{10}$/,
-  /* JP */ /*#__PURE__*//^\d{3}-\d{4}$/
+  /* JP */ /*#__PURE__*//^\d{3}-\d{4}$/,
+  /* UA */ /*#__PURE__*//^\d{5}$/,
 ];
 
 function _testPostalCode(postalCode: string) {

--- a/tests/PostalCode.test.ts
+++ b/tests/PostalCode.test.ts
@@ -235,6 +235,20 @@ describe('PostalCode', () => {
         expect(GraphQLPostalCode.parseLiteral({ value: '123-4567', kind: Kind.STRING }, {})).toBe('123-4567');
       });
     });
+
+    describe('Ukraine', () => {
+      test('serialize', () => {
+        expect(GraphQLPostalCode.serialize('08001')).toBe('08001');
+      });
+
+      test('parseValue', () => {
+        expect(GraphQLPostalCode.parseValue('08001')).toBe('08001');
+      });
+
+      test('parseLiteral', () => {
+        expect(GraphQLPostalCode.parseLiteral({ value: '08001', kind: Kind.STRING }, {})).toBe('08001');
+      });
+    });
   });
 
   describe('invalid', () => {

--- a/website/src/pages/docs/scalars/postal-code.mdx
+++ b/website/src/pages/docs/scalars/postal-code.mdx
@@ -20,6 +20,7 @@ Which gives us the following countries:
 - IN - India
 - IR - Iran
 - JP - Japan
+- UA - Ukraine
 
 This is a practical decision of weight (of the package) vs. completeness.
 


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

This PR adds a new regex for the Ukrainian postal code in the PostalCode scalar.

Refferance: https://en.wikipedia.org/wiki/Postal_codes_in_Ukraine

> Ukraine uses five-digit numeric postal codes that are written immediately to the right of the city or settlement name.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
