### PR TITLE
fix(issue-2139): bigint timestamps

### DIFF
--- a/src/scalars/iso-date/DateTime.ts
+++ b/src/scalars/iso-date/DateTime.ts
@@ -33,7 +33,7 @@ export const GraphQLDateTimeConfig: GraphQLScalarTypeConfig<Date, Date> = /*#__P
       throw createGraphQLError(`DateTime cannot represent an invalid date-time-string ${value}.`);
     } else if (typeof value === 'number') {
       try {
-        return new Date(value);
+        return new Date(value * 1000);
       } catch (e) {
         throw createGraphQLError('DateTime cannot represent an invalid Unix timestamp ' + value);
       }


### PR DESCRIPTION
## Description

This resolves the problem with using a bigint for timestamps in the database. 

Related #2139

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Run the same test as provided in the issue.

**Test Environment**:
- OS:
- GraphQL Scalars Version:
- NodeJS:

## Checklist:

- [] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
