### PR TITLE
fix(scalars): Latitude and Longitude inconsistent types

### DIFF
--- a/src/scalars/Latitude.ts
+++ b/src/scalars/Latitude.ts
@@ -73,7 +73,7 @@ export const GraphQLLatitude = /*#__PURE__*/ new GraphQLScalarType({
     return validate(ast.value, ast);
   },
   extensions: {
-    codegenScalarType: 'string',
+    codegenScalarType: 'string | number',
     jsonSchema: {
       title: 'Latitude',
       type: 'number',

--- a/src/scalars/Longitude.ts
+++ b/src/scalars/Longitude.ts
@@ -75,6 +75,7 @@ export const GraphQLLongitude = /*#__PURE__*/ new GraphQLScalarType({
   extensions: {
     codegenScalarType: 'string | number',
     jsonSchema: {
+      title: 'Longitude',
       type: 'number',
       minimum: MIN_LON,
       maximum: MAX_LON,


### PR DESCRIPTION
## Description

This will fix the inconsistent types for code-gen for `Latitude` and `Longitude` scalars.

Related [#2168](https://github.com/Urigo/graphql-scalars/issues/2168)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):
N/A

## How Has This Been Tested?
N/A

**Test Environment**:
- OS: Ubuntu 22.04.3 LTS
- GraphQL Scalars Version: 1.22.4
- NodeJS: v18.16.0

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
