### PR TITLE
fix(JSONObject): Throw proper error if literal is not an object

### DIFF
--- a/.changeset/hip-games-glow.md
+++ b/.changeset/hip-games-glow.md
@@ -1,0 +1,5 @@
+---
+'graphql-scalars': patch
+---
+
+fix(JSONObject): Throw proper error if literal is not an object

--- a/src/scalars/json/utils.ts
+++ b/src/scalars/json/utils.ts
@@ -1,4 +1,4 @@
-import { Kind, ValueNode, ObjectValueNode } from 'graphql';
+import { Kind, print, ValueNode } from 'graphql';
 import { createGraphQLError } from '../../error.js';
 
 export function identity<T>(value: T): T {
@@ -21,7 +21,18 @@ export function ensureObject(value: any, ast?: ValueNode): object {
   return value;
 }
 
-export function parseObject(ast: ObjectValueNode, variables: any): any {
+export function parseObject(ast: ValueNode, variables: any): any {
+  if (ast.kind !== Kind.OBJECT) {
+    throw createGraphQLError(
+      `JSONObject cannot represent non-object value: ${print(ast)}`,
+      ast
+        ? {
+            nodes: ast,
+          }
+        : undefined,
+    );
+  }
+
   const value = Object.create(null);
   ast.fields.forEach(field => {
     // eslint-disable-next-line no-use-before-define

--- a/tests/JSON.test.ts
+++ b/tests/JSON.test.ts
@@ -292,6 +292,7 @@ describe('GraphQLJSONObject', () => {
       }).then(({ data, errors }) => {
         expect(data).toBeUndefined();
         expect(errors).toBeDefined();
+        expect(errors).toMatchSnapshot();
       }));
 
     it('should reject array literal', () =>

--- a/tests/__snapshots__/JSON.test.ts.snap
+++ b/tests/__snapshots__/JSON.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GraphQLJSONObject parseLiteral should reject string literal 1`] = `
+[
+  [GraphQLError: JSONObject cannot represent non-object value: "foo"],
+]
+`;


### PR DESCRIPTION
## Description

This PR handles the literal for `JSONObject` not being an object and throws a proper error.

Related #2285

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

In my local project I copied the dist/esm dir into my node modules and verified the error is now correct.

It now looks like
```
"JSONObject cannot represent non-object value: \"test\""
```
instead of
```
"Expected value of type \"JSONObject\", found \"test\"; Cannot read properties of undefined (reading 'forEach')"
```

**Test Environment**:
- OS: Mac
- GraphQL Scalars Version: This commit
- NodeJS: Cloudflare Wrangler

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
