### PR TITLE
add graphql conf 2024 banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![scalar](https://user-images.githubusercontent.com/25294569/63675022-87723c80-c7f0-11e9-87b9-22c78c9a17e2.gif)](https://www.graphql-scalars.dev)
+[![GraphQLConf 2024 Banner: September 10-12, San Francisco. Hosted by the GraphQL Foundation](https://github.com/user-attachments/assets/bdb8cd5d-5186-4ece-b06b-b00a499b7868)](https://graphql.org/conf/2024/?utm_source=github&utm_medium=graphql_scalars&utm_campaign=readme)
+
+<!-- Uncomment when we remove GraphQL Conf banner -->
+<!-- [![scalar](https://user-images.githubusercontent.com/25294569/63675022-87723c80-c7f0-11e9-87b9-22c78c9a17e2.gif)](https://www.graphql-scalars.dev) -->
 
 [![npm version](https://badge.fury.io/js/graphql-scalars.svg)](https://badge.fury.io/js/graphql-scalars)
 [![Discord Chat](https://img.shields.io/discord/625400653321076807)](https://discord.gg/xud7bH9)


### PR DESCRIPTION
Way to boost GraphQL Conf. Discussed on [Slack](https://guild-oss.slack.com/archives/C03J3MBLJ6M/p1722873867810819).
