### PR TITLE
Fix typo in timestamp.mdx

### DIFF
--- a/website/src/pages/docs/scalars/timestamp.mdx
+++ b/website/src/pages/docs/scalars/timestamp.mdx
@@ -2,7 +2,7 @@ import { Callout } from '@theguild/components'
 
 # Timestamp
 
-The JavaScript `Date` is an integer. Type represents date and time as number of milliseconds from
+The JavaScript `Date` as integer. Type represents date and time as number of milliseconds from
 start of the UNIX epoch.
 
 <Callout>


### PR DESCRIPTION
Text is now in sync with the GraphQLTimestamp resolver description in the code.