### PR TITLE
PhoneNumber scalar is not fully compatible with E.164 format so updated regex to support phone number with extension

### DIFF
--- a/src/scalars/PhoneNumber.ts
+++ b/src/scalars/PhoneNumber.ts
@@ -1,7 +1,11 @@
 import { GraphQLScalarType, Kind } from 'graphql';
 import { createGraphQLError } from '../error.js';
 
-const PHONE_NUMBER_REGEX = /^\+[1-9]\d{6,14}$/;
+// The regex supports all phone numbers compliant with the E.164 international format standard,
+// which includes country codes (Optional), area codes, and local numbers and extension (optional). For more information on E.164 formatting,
+// Regex: https://regex101.com/r/nol2F6/1
+// Ex. +62 (21) 9175 5194, 2191755194, +1 123-456-7890 12345, +1 (123) 456-7890
+const PHONE_NUMBER_REGEX = /^\+?\d{1,3}(\-|\x20)?\(?\d+\)?((\-|\x20)?\d+)+$/;
 
 export const GraphQLPhoneNumber = /*#__PURE__*/ new GraphQLScalarType({
   name: 'PhoneNumber',
@@ -16,7 +20,7 @@ export const GraphQLPhoneNumber = /*#__PURE__*/ new GraphQLScalarType({
 
     if (!PHONE_NUMBER_REGEX.test(value)) {
       throw createGraphQLError(
-        `Value is not a valid phone number of the form +17895551234 (7-15 digits): ${value}`,
+        `Invalid phone number: ${value}. Please ensure it's in a valid format. The country code is optional, and Spaces and dashes are allowed. Examples: +1 (123) 456-7890, +44 (20) 2121 2222, or 123 456-7890.`,
       );
     }
 
@@ -30,7 +34,7 @@ export const GraphQLPhoneNumber = /*#__PURE__*/ new GraphQLScalarType({
 
     if (!PHONE_NUMBER_REGEX.test(value)) {
       throw createGraphQLError(
-        `Value is not a valid phone number of the form +17895551234 (7-15 digits): ${value}`,
+        `Invalid phone number: ${value}. Please ensure it's in a valid format. The country code is optional, and Spaces and dashes are allowed. Examples: +1 (123) 456-7890, +44 (20) 2121 2222, or 123 456-7890.`,
       );
     }
 
@@ -47,7 +51,7 @@ export const GraphQLPhoneNumber = /*#__PURE__*/ new GraphQLScalarType({
 
     if (!PHONE_NUMBER_REGEX.test(ast.value)) {
       throw createGraphQLError(
-        `Value is not a valid phone number of the form +17895551234 (7-15 digits): ${ast.value}`,
+        `Invalid phone number: ${ast.value}. Please ensure it's in a valid format. The country code is optional, and Spaces and dashes are allowed. Examples: +1 (123) 456-7890, +44 (20) 2121 2222, or 123 456-7890.`,
         { nodes: ast },
       );
     }

--- a/tests/PhoneNumber.test.ts
+++ b/tests/PhoneNumber.test.ts
@@ -3,44 +3,80 @@
 import { Kind } from 'graphql/language';
 import { GraphQLPhoneNumber } from '../src/scalars/PhoneNumber.js';
 
+function PhoneNumberError(value: string) {
+  return `Invalid phone number: ${value}. Please ensure it's in a valid format. The country code is optional, and Spaces and dashes are allowed. Examples: +1 (123) 456-7890, +44 (20) 2121 2222, or 123 456-7890.`
+}
+
 describe('PhoneNumber', () => {
-  describe('valid', () => {
-    test('serialize', () => {
-      expect(GraphQLPhoneNumber.serialize('+16075551234')).toBe('+16075551234');
-    });
-
-    test('parseValue', () => {
-      expect(GraphQLPhoneNumber.parseValue('+16075551234')).toBe('+16075551234');
-    });
-
-    test('parseLiteral', () => {
-      expect(
-        GraphQLPhoneNumber.parseLiteral({ value: '+16075551234', kind: Kind.STRING }, {}),
-      ).toBe('+16075551234');
-    });
-  });
-
-  describe('invalid', () => {
-    describe('not a phone number', () => {
+  describe('valid formats', () => {
+    describe('with country code', () => {
       test('serialize', () => {
-        expect(() => GraphQLPhoneNumber.serialize('this is not a phone number')).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
-        );
+        expect(GraphQLPhoneNumber.serialize('+16075551234')).toBe('+16075551234');
       });
 
       test('parseValue', () => {
-        expect(() => GraphQLPhoneNumber.parseValue('this is not a phone number')).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
-        );
+        expect(GraphQLPhoneNumber.parseValue('+16075551234')).toBe('+16075551234');
+      });
+
+      test('parseLiteral', () => {
+        expect(
+          GraphQLPhoneNumber.parseLiteral({ value: '+16075551234', kind: Kind.STRING }, {}),
+        ).toBe('+16075551234');
+      });
+    });
+    describe('without country code', () => {
+      test('serialize', () => {
+        expect(() => GraphQLPhoneNumber.serialize('7895551234')).not.toThrow()
+      });
+
+      test('parseValue', () => {
+        expect(() => GraphQLPhoneNumber.parseValue('123 456-7890')).not.toThrow()
+      });
+
+      test('parseLiteral', () => {
+        expect(() =>
+          GraphQLPhoneNumber.parseLiteral({ value: '789 555 1234', kind: Kind.STRING }, {}),
+        ).not.toThrow();
+      });
+    });
+    describe('different formatting', () => {
+      test('serialize', () => {
+        expect(() => GraphQLPhoneNumber.serialize('62-(21)-9175-5194')).not.toThrow()
+      });
+
+      test('serialize', () => {
+        expect(() => GraphQLPhoneNumber.serialize('+622191755194')).not.toThrow()
+      });
+
+      test('parseValue', () => {
+        expect(() => GraphQLPhoneNumber.parseValue('+62 (21) 9175 5194')).not.toThrow()
+      });
+
+      test('parseLiteral', () => {
+        expect(() =>
+          GraphQLPhoneNumber.parseLiteral({ value: '+1 (123) 456-7890', kind: Kind.STRING }, {}),
+        ).not.toThrow();
+      });
+    });
+  });
+
+  describe('invalid case', () => {
+    describe('contains Non-Numeric Characters', () => {
+      test('serialize', () => {
+        expect(() => GraphQLPhoneNumber.serialize('98aaa333')).toThrow(PhoneNumberError('98aaa333'));
+      });
+
+      test('parseValue', () => {
+        expect(() => GraphQLPhoneNumber.parseValue('98aaa333ppp')).toThrow(PhoneNumberError('98aaa333ppp'));
       });
 
       test('parseLiteral', () => {
         expect(() =>
           GraphQLPhoneNumber.parseLiteral(
-            { value: 'this is not a phone number', kind: Kind.STRING },
+            { value: '98aa', kind: Kind.STRING },
             {},
           ),
-        ).toThrow(/^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/);
+        ).toThrow(PhoneNumberError('98aa'));
       });
     });
 
@@ -60,65 +96,46 @@ describe('PhoneNumber', () => {
       });
     });
 
-    describe('too long', () => {
+    describe('wrong formate', () => {
       test('serialize', () => {
-        expect(() => GraphQLPhoneNumber.serialize('+1789555123456789')).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
-        );
+        expect(() => GraphQLPhoneNumber.serialize('+17 89- 5')).toThrow(PhoneNumberError('+17 89- 5'));
+      });
+
+      test('serialize', () => {
+        expect(() => GraphQLPhoneNumber.serialize('+1 ( 123 ) 456-7890')).toThrow(PhoneNumberError('+1 ( 123 ) 456-7890'));
+      });
+
+      test('serialize', () => {
+        expect(() => GraphQLPhoneNumber.serialize('+1[123]456 7890')).toThrow(PhoneNumberError('+1[123]456 7890'));
       });
 
       test('parseValue', () => {
-        expect(() => GraphQLPhoneNumber.parseValue('+1789555123456789')).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
-        );
+        expect(() => GraphQLPhoneNumber.parseValue('+(178)95 55 5678')).toThrow(PhoneNumberError('+(178)95 55 5678'));
       });
 
       test('parseLiteral', () => {
         expect(() =>
-          GraphQLPhoneNumber.parseLiteral({ value: '+1789555123456789', kind: Kind.STRING }, {}),
-        ).toThrow(/^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/);
+          GraphQLPhoneNumber.parseLiteral({ value: '1789 [555] 1234', kind: Kind.STRING }, {}),
+        ).toThrow(PhoneNumberError('1789 [555] 1234'));
       });
     });
 
     describe('too small', () => {
       test('serialize', () => {
-        expect(() => GraphQLPhoneNumber.serialize('+123')).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
-        );
+        expect(() => GraphQLPhoneNumber.serialize('+12')).toThrow(PhoneNumberError('+12'));
       });
 
       test('parseValue', () => {
-        expect(() => GraphQLPhoneNumber.parseValue('+123')).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
-        );
+        expect(() => GraphQLPhoneNumber.parseValue('+12')).toThrow(PhoneNumberError('+12'));
       });
 
       test('parseLiteral', () => {
         expect(() =>
-          GraphQLPhoneNumber.parseLiteral({ value: '+123', kind: Kind.STRING }, {}),
-        ).toThrow(/^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/);
+          GraphQLPhoneNumber.parseLiteral({ value: '+12', kind: Kind.STRING }, {}),
+        ).toThrow(PhoneNumberError('+12'));
       });
     });
 
-    describe('no plus sign', () => {
-      test('serialize', () => {
-        expect(() => GraphQLPhoneNumber.serialize('17895551234')).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
-        );
-      });
-
-      test('parseValue', () => {
-        expect(() => GraphQLPhoneNumber.parseValue('17895551234')).toThrow(
-          /^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/,
-        );
-      });
-
-      test('parseLiteral', () => {
-        expect(() =>
-          GraphQLPhoneNumber.parseLiteral({ value: '17895551234', kind: Kind.STRING }, {}),
-        ).toThrow(/^Value is not a valid phone number of the form \+17895551234 \(7-15 digits\)/);
-      });
-    });
     describe('support more countries', () => {
       test('support Singapore numbers - 10 digits', () => {
         expect(() => {


### PR DESCRIPTION
## Description

Following recent discussions, it was determined that phone number support does not fully comply with E.164 standards. As a result, we also need to support phone extensions, which is addressed in this PR. Additionally, comprehensive test coverage has been added to cover all possible phone number formats.

The regex supports all phone numbers compliant with the E.164 international format standard, which includes country code (Optional), area codes, and local numbers and extension (optional). For more information on E.164 formatting,
Regex: https://regex101.com/r/nol2F6/1

Ex. +62 (21) 9175 5194, 2191755194, +1 123-456-7890 12345, +1 (123) 456-7890 

Related https://github.com/Urigo/graphql-scalars/issues/2709

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- GraphQL Scalars Version:
- NodeJS:

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
