### PR TITLE
fix(scalars): add missing @specifiedBy URL to the HSLA scalar

### DIFF
--- a/.changeset/hsla-specified-by-url.md
+++ b/.changeset/hsla-specified-by-url.md
@@ -1,0 +1,5 @@
+---
+'graphql-scalars': patch
+---
+
+Expose the `@specifiedBy` URL on the `HSLA` scalar so it matches its sibling `HSL`. Both now point to the same MDN reference and emit the `@specifiedBy` directive in the schema.

--- a/src/scalars/HSLA.ts
+++ b/src/scalars/HSLA.ts
@@ -19,6 +19,9 @@ const validate = (value: any, ast?: ASTNode) => {
   return value;
 };
 
+const specifiedByURL =
+  'https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#hsl()_and_hsla()';
+
 export const GraphQLHSLA = /*#__PURE__*/ new GraphQLScalarType({
   name: `HSLA`,
 
@@ -41,6 +44,9 @@ export const GraphQLHSLA = /*#__PURE__*/ new GraphQLScalarType({
 
     return validate(ast.value, ast);
   },
+
+  specifiedByURL,
+  specifiedByUrl: specifiedByURL,
   extensions: {
     codegenScalarType: 'string',
     jsonSchema: {

--- a/tests/HSLA.test.ts
+++ b/tests/HSLA.test.ts
@@ -56,4 +56,10 @@ describe(`HSLA`, () => {
       });
     });
   });
+
+  it(`exposes a specifiedByURL like the HSL scalar`, () => {
+    expect(GraphQLHSLA.specifiedByURL).toBe(
+      `https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#hsl()_and_hsla()`,
+    );
+  });
 });


### PR DESCRIPTION
The `HSL` scalar sets `specifiedByURL` (plus the lowercase `specifiedByUrl` alias that graphql v15 reads), so its printed type is `scalar HSL @specifiedBy(url: "...")`. Its sibling `HSLA` was missing both keys, so it prints a bare `scalar HSLA` with no `@specifiedBy` directive, even though the MDN page they share (`#hsl()_and_hsla()`) covers both functions.

This just copies the same URL onto `HSLA` so the pair stays in sync. Output with `graphql` 16:

```diff
- scalar HSLA
+ scalar HSLA @specifiedBy(url: "https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#hsl()_and_hsla()")
```

I added a test asserting `GraphQLHSLA.specifiedByURL` matches HSL's. On `master` it fails with `Received: undefined`; with the change `jest tests/HSLA.test.ts tests/HSL.test.ts` is green (13 passing) and prettier is clean. Changeset included as a patch.
