### PR TITLE
fix(scalars): parse USCurrency amounts with multiple thousands separators

### DIFF
--- a/.changeset/fix-uscurrency-thousands-separators.md
+++ b/.changeset/fix-uscurrency-thousands-separators.md
@@ -1,0 +1,9 @@
+---
+'graphql-scalars': patch
+---
+
+Fix `USCurrency` parsing of amounts with more than one thousands separator
+
+`generateCents` stripped only the first comma, so a value like `$1,000,000.00` parsed to the wrong
+amount (`parseFloat` stopped at the second separator, yielding `$1,000.00`). It now removes every
+separator.

--- a/src/scalars/USCurrency.ts
+++ b/src/scalars/USCurrency.ts
@@ -16,7 +16,7 @@ function generateCurrency(value: any) {
 }
 
 function generateCents(value: string) {
-  const digits = value.replace('$', '').replace(',', '');
+  const digits = value.replace('$', '').replace(/,/g, '');
   const number = parseFloat(digits);
   return number * 100;
 }

--- a/tests/USCurrency.test.ts
+++ b/tests/USCurrency.test.ts
@@ -147,6 +147,22 @@ describe('USCurrency', () => {
     });
   });
 
+  it('should parse literal value with multiple thousands separators', () => {
+    const value = '$1,000,000.00';
+    const schema = createGraphQLSchema(noop, (source, { currencyValue }) => {
+      expect(currencyValue).toEqual(100000000);
+      return currencyValue;
+    });
+    const source = /* GraphQL */ `
+      mutation {
+        setCurrency(currencyValue:"${value}")
+      }
+    `;
+    return graphql({ schema, source }).then(result => {
+      expect(result.errors).toBeFalsy();
+    });
+  });
+
   it('should parse input string value', () => {
     const value = '$12.50';
     const schema = createGraphQLSchema(noop, (source, { currencyValue }) => {


### PR DESCRIPTION
`generateCents` stripped only the first thousands separator (`.replace(',', '')`), so an amount with more than one separator parsed to the wrong value — e.g. `$1,000,000.00` parsed as `$1,000.00`, because `parseFloat` stops at the second comma. It now removes every separator (`.replace(/,/g, '')`).

Adds a regression test (`$1,000,000.00` → `100000000` cents) that fails without the fix. The existing tests only used single-separator amounts (`$22,900.00`), which the one-comma replace happened to handle.
