### PR TITLE
fix(scripts): point setup-scalar at the current website docs path

### DIFF
--- a/scripts/setup-scalar.js
+++ b/scripts/setup-scalar.js
@@ -492,7 +492,7 @@ export { GraphQL${this.scalarName} };`;
   }*/
 
   async updateDocsMeta() {
-    const metaPath = path.join(this.baseDir, 'website/src/pages/docs/scalars/_meta.ts');
+    const metaPath = path.join(this.baseDir, 'website/src/content/scalars/_meta.ts');
     const metaEntry = this.formatMetaEntry(this.scalarName);
     await this.updateOrInsertContent(metaPath, 'export default', metaEntry, 'object');
   }
@@ -500,7 +500,7 @@ export { GraphQL${this.scalarName} };`;
   async createDocumentation() {
     const mdxPath = path.join(
       this.baseDir,
-      `website/src/pages/docs/scalars/${this.toKebabCase(this.scalarName)}.mdx`,
+      `website/src/content/scalars/${this.toKebabCase(this.scalarName)}.mdx`,
     );
 
     const mdxContent = `# ${this.scalarName}


### PR DESCRIPTION
The website documentation moved from `website/src/pages/docs/scalars/` to `website/src/content/scalars/`, but `scripts/setup-scalar.js` still writes the generated `_meta.ts` entry and `.mdx` file to the old path. As a result, a newly scaffolded scalar's documentation lands outside the docs tree.

This points both paths in the generator at the current location.
