### PR TITLE
fix(scalars): correct jsonSchema definitions that misdescribe their values

### DIFF
--- a/src/scalars/BigInt.ts
+++ b/src/scalars/BigInt.ts
@@ -103,8 +103,10 @@ export const GraphQLBigIntConfig: GraphQLScalarTypeConfig<
   extensions: {
     codegenScalarType: 'bigint',
     jsonSchema: {
-      type: 'integer',
-      format: 'int64',
+      // Not format: 'int64' — a BigInt is arbitrary-precision, not 64-bit-bounded,
+      // and it serializes as a number when within the safe-integer range or as a
+      // decimal string when larger (to avoid precision loss).
+      oneOf: [{ type: 'integer' }, { type: 'string', pattern: '^-?\\d+$' }],
     },
   },
 };

--- a/src/scalars/LocalDateTime.ts
+++ b/src/scalars/LocalDateTime.ts
@@ -68,7 +68,10 @@ export const LocalDateTimeConfig: GraphQLScalarTypeConfig<string, string> = /*#_
     jsonSchema: {
       title: 'LocalDateTime',
       type: 'string',
-      format: 'date-time',
+      // Not format: 'date-time' — RFC 3339 date-time mandates a timezone offset,
+      // but a LocalDateTime is intentionally offset-less. Match what the scalar
+      // actually validates, like LocalDate/LocalTime do.
+      pattern: LOCAL_DATE_TIME_REGEX.source,
     },
   },
 };

--- a/src/scalars/PostalCode.ts
+++ b/src/scalars/PostalCode.ts
@@ -121,8 +121,11 @@ export const GraphQLPostalCode = /*#__PURE__*/ new GraphQLScalarType({
     codegenScalarType: 'string',
     jsonSchema: {
       title: 'PostalCode',
-      oneOf: POSTAL_CODE_REGEXES.map(regex => ({
-        type: 'string',
+      type: 'string',
+      // anyOf, not oneOf: postal-code formats overlap across countries (e.g. a
+      // 5-digit code matches US, DE, FR, IT, ES, ... at once), so a valid code
+      // matches several patterns — oneOf would require it to match exactly one.
+      anyOf: POSTAL_CODE_REGEXES.map(regex => ({
         pattern: regex.source,
       })),
     },

--- a/src/scalars/Timestamp.ts
+++ b/src/scalars/Timestamp.ts
@@ -46,8 +46,8 @@ export const GraphQLTimestamp = /*#__PURE__*/ new GraphQLScalarType({
   extensions: {
     codegenScalarType: 'Date | string | number',
     jsonSchema: {
-      type: 'string',
-      format: 'unix-time',
+      // serialize() returns a number of milliseconds (Date#getTime), not a string.
+      type: 'integer',
     },
   },
 });

--- a/src/scalars/USCurrency.ts
+++ b/src/scalars/USCurrency.ts
@@ -64,7 +64,9 @@ export const GraphQLUSCurrency = /*#__PURE__*/ new GraphQLScalarType({
     jsonSchema: {
       title: 'USCurrency',
       type: 'string',
-      pattern: '^\\$[0-9]+(\\.[0-9]{2})?$',
+      // Matches the serialized toLocaleString form: optional leading minus, '$',
+      // grouped thousands and always two decimals — e.g. $21.25 or -$1,000.00.
+      pattern: '^-?\\$[0-9]{1,3}(,[0-9]{3})*\\.[0-9]{2}$',
     },
   },
 });

--- a/src/scalars/ssn/SE.ts
+++ b/src/scalars/ssn/SE.ts
@@ -6,7 +6,14 @@ import { createGraphQLError } from '../../error.js';
 // Algorithm:
 // https://swedish.identityinfo.net/personalidentitynumber
 
-const SESSN_PATTERNS = ['YYYYMMDDXXXX', 'YYMMDDXXXX'];
+// Structural patterns for the two accepted personnummer forms. Full validation
+// (date + Luhn checksum) lives in _isValidSwedishPersonalNumber; these only
+// describe the string shape for the jsonSchema. An optional -/+ separator is
+// allowed since non-digits are stripped before validation.
+const SESSN_PATTERNS = [
+  /^\d{8}[-+]?\d{4}$/, // YYYYMMDD(-)XXXX — 12 digits
+  /^\d{6}[-+]?\d{4}$/, // YYMMDD(-)XXXX   — 10 digits
+];
 
 function _isValidSwedishPersonalNumber(value: string): boolean {
   // Remove any non-digit characters
@@ -128,10 +135,9 @@ export const GraphQLSESSN: GraphQLScalarType = /*#__PURE__*/ new GraphQLScalarTy
     codegenScalarType: 'string',
     jsonSchema: {
       title: 'SESSN',
-      oneOf: SESSN_PATTERNS.map((pattern: string) => ({
-        type: 'string',
-        length: pattern.length,
-        pattern,
+      type: 'string',
+      anyOf: SESSN_PATTERNS.map(pattern => ({
+        pattern: pattern.source,
       })),
     },
   },


### PR DESCRIPTION
Several scalars ship a `jsonSchema` extension that rejects values the scalar serializes or declares the wrong type. This corrects each to match the serialized output.

Rejecting values the scalar accepts:
- **SESSN** — `SESSN_PATTERNS` held the format placeholders `YYYYMMDDXXXX` / `YYMMDDXXXX`, used verbatim as regex patterns, so they matched only that literal text and no real personnummer. The `length` beside them is not a JSON Schema keyword. Replaced with real patterns for the two accepted forms under `anyOf`.
- **PostalCode** — used `oneOf` over the per-country patterns, but postal formats overlap (a 5-digit code matches US, DE, FR, IT, ES at once), so a valid code matches several patterns and fails `oneOf`'s exactly-one requirement. Changed to `anyOf`.
- **LocalDateTime** — `format:'date-time'` mandates an RFC 3339 offset, which an offset-less LocalDateTime never has. Uses the scalar's own regex as `pattern`, like LocalDate and LocalTime.

Mismatched serialized output:
- **Timestamp** — declared `type:'string'`, but `serialize` returns a number of milliseconds. Now `type:'integer'`.
- **BigInt / Long** — `int64` implies a 64-bit bound a BigInt does not have and omits the decimal-string form used beyond the safe-integer range. Now `oneOf:[integer, numeric-string]`.
- **USCurrency** — the pattern forbade the thousands separators and leading minus that `toLocaleString` produces, so it rejected the scalar's own output above `$999` and for negatives. Widened to match.