### PR TITLE
fix(mocks): use valid mock values for GeoJSON and CountryName

### DIFF
--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -1,7 +1,30 @@
 export const ULID = () => '01J9GHQM8N5X4TQ3M1ZV9J6CBK';
 export const Cuid2 = () => 'dp71y53f6eykvl5g1393rmhl';
-export const GeoJSON = () => 'Example GeoJSON';
-export const CountryName = () => 'Example CountryName';
+export const GeoJSON = () => ({
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: { name: 'Sample Point' },
+      geometry: {
+        type: 'Point',
+        coordinates: [12.4924, 41.8902], // e.g. near the Colosseum in Rome
+      },
+    },
+    {
+      type: 'Feature',
+      properties: { name: 'Sample Line' },
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [12.4924, 41.8902],
+          [12.4964, 41.9028], // simple line segment
+        ],
+      },
+    },
+  ],
+});
+export const CountryName = () => 'United States of America';
 const BigIntMock = () => BigInt(Number.MAX_SAFE_INTEGER);
 const ByteMock = () => new Uint8Array([1988, 1981, 1965, 1963, 1959, 1955]);
 const DateMock = () => '2007-12-03';


### PR DESCRIPTION
The `GeoJSON` and `CountryName` mocks returned values their scalars reject, so mocking the scalar produced a value it cannot serialize:

- `GeoJSON` returned the string `'Example GeoJSON'`, but the scalar validates GeoJSON objects — now a valid `FeatureCollection`.
- `CountryName` returned `'Example CountryName'`, which is not a real country name — now `'United States of America'`, matching the `CountryCode` mock (`'US'`).
